### PR TITLE
Tidy skip-link styling

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -102,6 +102,12 @@ body {
 
 	}
 
+	// Override overly specific TwentyThirteen styles
+	.skip-link.skip-link:focus {
+		color: $brand-primary;
+		top: -2px;
+	}
+
 	.menu-toggle {
 		color: $white;
 	}


### PR DESCRIPTION
The position and colour of the pre-nav skip link is inheriting from the Twenty Thirteen styles, and the white on grey is unreadable.