### PR TITLE
Move organiser photos to the right

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -767,6 +767,11 @@ article {
 
 }
 
+.wcorg-organizer-description img {
+	float: right;
+	margin: 0 0 20px 20px;
+}
+
 .email-only {
 	display: none !important;
 }


### PR DESCRIPTION
Changes it from:

![screenshot 2017-01-12 11 19 48](https://cloud.githubusercontent.com/assets/88371/21887750/1cf36268-d8b9-11e6-9e81-0132a7eb0e21.png)

...to:

![screenshot 2017-01-12 11 19 37](https://cloud.githubusercontent.com/assets/88371/21887751/1cf36b64-d8b9-11e6-8c53-eda357c3cea9.png)
